### PR TITLE
Add PHPDoc helper

### DIFF
--- a/Laravel-Blade.xml
+++ b/Laravel-Blade.xml
@@ -313,10 +313,10 @@
       <option name="HTML" value="true" />
     </context>
   </template>
-  <template name="@doc" value="@php&#10;    /**&#10;    * @var $START$ $END$&#10;    */&#10;@endphp" description="Add PHPDoc to Blade" toReformat="true" toShortenFQNames="true">
+  <template name="@doc" value="@php&#10;   /**&#10;    * @var $START$ $END$&#10;    */&#10;@endphp" description="Add PHPDOC to blade" toReformat="false" toShortenFQNames="true">
     <variable name="START" expression="" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="HTML" value="true" />
     </context>
-  </template>
+</template>
 </templateSet>

--- a/Laravel-Blade.xml
+++ b/Laravel-Blade.xml
@@ -313,4 +313,10 @@
       <option name="HTML" value="true" />
     </context>
   </template>
+  <template name="@doc" value="@php&#10;    /**&#10;    * @var $START$ $END$&#10;    */&#10;@endphp" description="Add PHPDoc to Blade" toReformat="true" toShortenFQNames="true">
+    <variable name="START" expression="" defaultValue="" alwaysStopAt="true" />
+    <context>
+      <option name="HTML" value="true" />
+    </context>
+  </template>
 </templateSet>

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ e.g. `~/Library/Preferences/PhpStorm2017.2/templates` on OS X for PhpStorm 2017
 * **@includeIf** : Blade @includeIf
 * **@includeFirst** : Blade @includeFirst
 * **@prepend** : Blade @prepend
+* **@doc** : Blade @php /** PHPDoc */
 
 ## Contributing
 1. Fork it


### PR DESCRIPTION
Provide a convenient way to add PHPDoc block to Blade using `@doc`
It will generate

```
@php
   /**
    * @var $START$ $END$
    */
@endphp
```